### PR TITLE
Feature/client-request-handling クライアントからのリクエスト処理とレスポンス送信

### DIFF
--- a/client.py
+++ b/client.py
@@ -118,10 +118,28 @@ if __name__ == "__main__":
 
     tcp_client.send_request(data)
 
-    data = tcp_client.receive_response()
-    data = data.decode("utf-8")
+    #data = tcp_client.receive_response()
+    #data = data.decode("utf-8")
 
-    print(data)
+    #print(data)
+
+    #サーバからの処理確認用
+
+    response_data = tcp_client.receive_response().decode("utf-8")
+    
+    try:
+        response = json.loads(response_data)
+        print(response["message"])
+
+        if response.get("state") == 2:
+            print("ルーム作成成功")
+            token = response.get("token")
+            print(f"トークン: {token}")
+        elif response.get("state") == 1:
+            print("ルーム作成失敗")
+    except json.JSONDecodeError:
+        print("サーバーからの応答が不正です。内容:", response_data)
+      
 
     tcp_client.close()
 
@@ -129,4 +147,4 @@ if __name__ == "__main__":
     udp_client = UDPClient("127.0.0.1", 8080)
     udp_client.send(b"UDPClient: Hello, server!")
     print(udp_client.receive())
-    udp_client.close()
+    udp_client.close

--- a/server.py
+++ b/server.py
@@ -86,13 +86,24 @@ class TCPServer:
                 operation_payload_bytes = client_socket.recv(operation_payload_len)
                 operation_payload = json.loads(operation_payload_bytes.decode("utf-8"))
 
-                print(f"データ受信: room_name={room_name}, operation={operation}, state={state}, payload={operation_payload}")
+                #print(f"データ受信: room_name={room_name}, operation={operation}, state={state}, payload={operation_payload}")
 
                 response = {}
+                
                 user_name = operation_payload.get("user_name")
                 password = operation_payload.get("password", "")
                 token = operation_payload.get("token", None)
                 udp_port = operation_payload.get("udp_port", None)
+
+                print("-------- リクエスト元のクライアント情報 --------")
+                print(f"接続元: {client_address[0]}:{client_address[1]}")
+                print(f"操作種類: {'ルーム作成' if operation == 1 else 'ルーム参加' if operation == 2 else '不明'}")
+                print(f"ルーム名: {room_name}")
+                print(f"ユーザー名: {user_name}")
+                print(f"パスワード: {password}")
+                print(f"UDPポート: {udp_port}")
+                print(f"受信状態コード: {state}")
+                print("----------------------------------")
 
                 if operation == 1:
                     if room_name in self.rooms_list:

--- a/server.py
+++ b/server.py
@@ -169,7 +169,7 @@ class TCPServer:
                             }
 
                             response = {
-                                "message": f"ルーム '{room_name}' に参加hしました。",
+                                "message": f"ルーム '{room_name}' に参加しました。",
                                 "operation": operation,
                                 "status": 2,
                                 "user_name": user_name,


### PR DESCRIPTION
## タスク
- クライアントのリクエスト処理 (server.py)
- クライアントへのレスポンス送信(server.py)

## 実装の詳細
リクエストからのヘッダーからデータを取得
クライアントへレスポンス送信

#### operation == 1:　新規ルーム作成の処理

- 同名ルームは存在する場合はエラーメッセージを返却
- 存在しない場合tokenを生成してroom{} token{}に登録

#### operation == 2:　既存ルームへ参加の処理

- ルームのの有無を確認、その後パスワード一致の検証
- パスワードが正しい場合member, token を登録

#### operation　が1でも2でもない場合エラーレスポンス

## 確認事項
クライアントのルーム作成、参加が可能なこと
ルームが存在している場合やパスワードが一致していない場合などはレスポンス送信をしていること


## 実行時
![Screenshot 2025-05-22 at 9 55 50 PM](https://github.com/user-attachments/assets/6b7fa326-17f0-484d-80cb-bcd9f9f63dd6)
