### PR TITLE
Feature/udp client sending

### DIFF
--- a/client.py
+++ b/client.py
@@ -89,10 +89,27 @@ class UDPClient:
         self.port = port
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-    def send(self, data):
-        self.sock.sendto(data, (self.address, self.port))
+    def send_message(self, room_name, token, message):
+        room_name_bytes = room_name.encode("utf-8")
+        token_bytes = token.encode("utf-8")
+        message_bytes = message.encode("utf-8")
+        
+        header = (
+            len(room_name_bytes).to_bytes(1, "big") +
+            len(token_bytes).to_bytes(1, "big")
+        )
+        
+        body = (
+            room_name_bytes +
+            token_bytes +
+            message_bytes
+        )
+        
+        packet = header + body
+        
+        self.sock.sendto(packet, (self.address, self.port))
 
-    def receive(self):
+    def receive_message(self):
         return self.sock.recvfrom(1024)
 
     def close(self):
@@ -145,6 +162,8 @@ if __name__ == "__main__":
 
     # UDPクライアントの実行
     udp_client = UDPClient("127.0.0.1", 8080)
-    udp_client.send(b"UDPClient: Hello, server!")
-    print(udp_client.receive())
-    udp_client.close
+    print(f"{user_name} がルーム {room_name} に参加しました。")
+    
+    while True:
+        message = input(f"{user_name}> ")
+        udp_client.send_message(room_name, token, message)

--- a/client.py
+++ b/client.py
@@ -1,6 +1,17 @@
 import socket
 import json
 
+
+# ユーザー名入力で空白を受け付けない
+def get_empty_input(prompt):
+    while True:
+        user_input = input(prompt).strip()
+        if user_input:
+            return user_input
+        else:
+            print("入力が無効です。もう一度入力してください。\n")
+
+
 # TCPクライアント
 
 class TCPClient:
@@ -12,7 +23,7 @@ class TCPClient:
 
     def input_user_name_and_operation(self):
         while True:
-            user_name = input("ユーザー名を入力してください: ")
+            user_name = get_empty_input("ユーザー名を入力してください: ").strip()
             if not user_name:
                 continue
             break
@@ -32,17 +43,17 @@ class TCPClient:
     def input_room_name_and_password(self, operation):
         while True:
             if operation == "1":
-                room_name = input("作成するルームの名前を入力してください: ")
+                room_name = get_empty_input("作成するルームの名前を入力してください: ")
                 if not room_name:
                     continue
-                password = input("パスワードを設定してください: ")
+                password = input("パスワードを設定してください: ").strip()
                 break
 
             elif operation == "2":
-                room_name = input("参加するルームの名前を入力してください: ")
+                room_name = get_empty_input("参加するルームの名前を入力してください: ")
                 if not room_name:
                     continue
-                password = input("パスワードを入力してください: ")
+                password = input("パスワードを入力してください: ").strip()
                 break
 
         return room_name, password

--- a/client.py
+++ b/client.py
@@ -1,6 +1,5 @@
 import socket
 import json
-import datetime
 
 # TCPクライアント
 

--- a/server.py
+++ b/server.py
@@ -47,6 +47,10 @@ import threading
 #     ...
 # }
 
+# ルーム情報とトークン情報のグローバル変数
+rooms_list = {}
+token_list = {}
+
 # TCPサーバー
 
 class TCPServer:
@@ -57,8 +61,8 @@ class TCPServer:
         self.sock.bind((self.address, self.port))
         self.sock.listen()
 
-        self.rooms_list = {}
-        self.token_list = {}
+        self.rooms_list = rooms_list
+        self.token_list = token_list
         
 
     def recieve_request(self):
@@ -220,8 +224,8 @@ class TCPServer:
 
 class UDPServer:
     def __init__(self, address, port):
-        self.room_list = {}
-        self.token_list = {}
+        self.room_list = rooms_list
+        self.token_list = token_list
 
         self.address = address
         self.port = port

--- a/server.py
+++ b/server.py
@@ -245,7 +245,7 @@ class UDPServer:
     def start(self):
         print(f"UDPサーバー起動 {self.address}:{self.port}")
         while True:
-            data, addr = self.sock.recvfrom(1024)
+            data, addr = self.sock.recvfrom(4096)
             print(f"{addr}: {data} を受信(UDP)")
             self.sock.sendto(b"UDPServerHello, client!", addr)
 

--- a/server.py
+++ b/server.py
@@ -78,7 +78,7 @@ class TCPServer:
         print(f"TCPサーバー起動 {self.address}:{self.port}")
         while True:
             client_socket, client_address = self.sock.accept()
-            print(f"{client_address} から接続")
+            print(f"\n{client_address} から接続")
 
             try:
                 header_data = client_socket.recv(32)
@@ -98,25 +98,13 @@ class TCPServer:
                 operation_payload_bytes = client_socket.recv(operation_payload_len)
                 operation_payload = json.loads(operation_payload_bytes.decode("utf-8"))
 
-                #print(f"データ受信: room_name={room_name}, operation={operation}, state={state}, payload={operation_payload}")
 
                 response = {}
-                
+
                 user_name = operation_payload.get("user_name")
                 password = operation_payload.get("password", "")
-                token = operation_payload.get("token", None)
                 udp_port = operation_payload.get("udp_port", None)
 
-                print("-------- リクエスト元のクライアント情報 --------")
-                print(f"接続元: {client_address[0]}:{client_address[1]}")
-                print(f"操作種類: {'ルーム作成' if operation == 1 else 'ルーム参加' if operation == 2 else '不明'}")
-                print(f"ルーム名: {room_name}")
-                print(f"ユーザー名: {user_name}")
-                print(f"パスワード: {password}")
-                print(f"UDPポート: {udp_port}")
-                print(f"受信状態コード: {state}")
-                print("----------------------------------")
-            
                 with list_lock:
                     if operation == 1:
                         if room_name in self.rooms_list:
@@ -189,6 +177,18 @@ class TCPServer:
                                     "token": new_token
                                 }
 
+                print("\n---------- リクエスト元のTCPクライアント情報 ----------")
+                print(f"接続元: ('{client_address[0]}', {client_address[1]})")
+                print(f"操作種類: {'ルーム作成' if operation == 1 else 'ルーム参加' if operation == 2 else '不明'}")
+                print(f"ルーム名: {room_name}")
+                print(f"ユーザー名: {user_name}")
+                print(f"パスワード: {password}")
+                print(f"ホスト: {'True' if operation == 1 else 'False' if operation == 2 else '不明'}")
+                print(f"状態コード: " + str(response.get("state")))
+                print(f"メッセージ: " + str(response.get("message")))
+                print(f"トークン: " + str(response.get("token")))
+                print("------------------------------------------------------")
+
                 response_data = json.dumps(response).encode("utf-8")
                 client_socket.sendall(response_data)
 
@@ -197,30 +197,6 @@ class TCPServer:
 
             finally:
                 client_socket.close()
-
-            # 以下ヘッダー・ボディのデコードのテスト
-
-            # ヘッダーのデコード
-            # room_name_len = int.from_bytes(header_data[0:1], "big")
-            # operation = int.from_bytes(header_data[1:2], "big")
-            # state = int.from_bytes(header_data[2:3], "big")
-            # operation_payload_len = int.from_bytes(header_data[3:32], "big")
-
-            # print(f"room_name_len: {room_name_len}")
-            # print(f"operation: {operation}")
-            # print(f"state: {state}")
-            # print(f"operation_payload_len: {operation_payload_len}")
-
-            # room_name_bytes = client_socket.recv(room_name_len)
-
-            # ルームネームのデコード
-            # room_name = room_name_bytes.decode("utf-8")
-            # print(f"room_name: {room_name}")
-
-            # オペレーションペイロードのデコード
-            # operation_payload_bytes = client_socket.recv(operation_payload_len)
-            # operation_payload = json.loads(operation_payload_bytes.decode("utf-8"))
-            # print(f"operation_payload: {operation_payload}")
 
 
     def send_response(self, data):


### PR DESCRIPTION
## タスク
### client.py
・クライアントのメッセージ入力を受け付ける処理
・UDPプロトコルに従ってのデータのエンコード処理
・エンコードしてまとめたパケットをUDPサーバーに送信する処理
・client.pyのimport datetimeを削除

### server.py
・**rooms_list, token_listをグローバル変数化**
・**threading.Lockの導入**
・クライアントからのパケットを受信

## 実装の詳細
・TCP通信終了後に、クライアントが自動でcloseすることがないようにしています。
・UDPサーバーに対してメッセージをいつでも送信できるような状態にしています。
・メッセージの入力後、ルーム名, トークン, メッセージをエンコードして、ヘッダーとボディをパケットにまとめます。
・このパケットをUDPサーバーに送信します。
・UDPサーバー側で、クライアントのIPアドレス, UDPポート番号, トークン, メッセージを表示する
　簡易的な処理を実装しています。

・threading Lockを導入しました（現在は、server.pyの120行目から190行目まで）

・listのグローバル変数化の理由：それぞれのリストをTCPServer, UDPServerで扱えるようにするためです。
・threading Lockの導入理由：複数のスレッドが同時に共有データ（rooms_list, token_list内のデータ）を書き換えてしまい、
　データが壊れたり、意図しない結果になったりすることを防ぐためです。

## 確認事項
・UDP通信開始後、メッセージの送信後にクライアントが自動でcloseすることがないこと
・複数のクライアントが同ルームに参加が可能であり、メッセージの送信ができること（他クライアントへの中継は考慮しない）
・UDPサーバー側でパケットを受信し、その詳細をprint文で簡易的に表示できること
・UDPサーバーが受信できるパケットは最大4096バイトであること